### PR TITLE
feat: build future-compatible python distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 repository = "https://github.com/2bndy5/redist-icons"
 
 [workspace.dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module"] }
+pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py39"] }


### PR DESCRIPTION
- minimum supported python is still v3.9.x
- uses pyo3 crate's `abi3-py39` feature