### PR TITLE
fix: escape HTML color values' `#`

### DIFF
--- a/crates/fontawesome/main.ts
+++ b/crates/fontawesome/main.ts
@@ -114,7 +114,7 @@ def get_icon(slug: str) -> Icon | None: ...
         rsIcons[key].src.push(`
 /// ${family}/${slug}
 pub const ${constName}: Icon = Icon {
-    svg: r#"${optimized.data}"#,
+    svg: r##"${optimized.data}"##,
     slug: "${slug}",
     last_modified: ${data.lastModified},
     family: "${family}",

--- a/crates/mdi/main.ts
+++ b/crates/mdi/main.ts
@@ -80,7 +80,7 @@ def get_icon(slug: str) -> Icon | None: ...
 
     const docComment = `\n/// ${slug}`;
     const appendSrc = `\npub const ${constName}: Icon = Icon {
-    svg: r#"${optimized.data}"#,
+    svg: r##"${optimized.data}"##,
     slug: "${slug}",
     version: "${iconMeta.version}",
     deprecated: ${iconMeta.deprecated},

--- a/crates/octicons/main.ts
+++ b/crates/octicons/main.ts
@@ -86,7 +86,7 @@ def get_icon(slug: str) -> Icon | None: ...
     rsLibIcons.src.push(`
 /// ${name}
 pub const ${constName}: Icon = Icon {
-    svg: r#"${optimized.data}"#,
+    svg: r##"${optimized.data}"##,
     slug: "${name}",\n};\n`);
   }
 

--- a/crates/simple-icons/main.ts
+++ b/crates/simple-icons/main.ts
@@ -86,7 +86,7 @@ def get_icon(slug: str) -> Icon | None: ...
     }
     const appendSrc = `\n/// ${slug}
 pub const ${constName}: Icon = Icon {
-    svg: r#"${optimized.data}"#,
+    svg: r##"${optimized.data}"##,
     slug: "${slug}",
     title: "${iconMeta.title}",
     hex: "${iconMeta.hex}",


### PR DESCRIPTION
Some packages (octicons) accidentally deploy icons which have a color attribute hard-coded in the SVG data.

```xml
fill="#000"
```
This causes syntax errors in the generated rust code.

This patch fixes that by escaping any `"#` found within the SVG string.