### PR TITLE
fix: use explicit paths in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,13 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: deno # zizmor: ignore[dependabot-cooldown]
-    directory: /
+    directories:
+      - /
+      - /common
+      - /crates/fontawesome
+      - /crates/mdi
+      - /crates/octicons
+      - /crates/simple-icons
     schedule:
       interval: "daily"
       # run sunday, tuesday, and thursday

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "octicons-pack"
-version = "19.28.0"
+version = "19.28.1"
 dependencies = [
  "pyo3",
 ]
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "simple-icons-pack"
-version = "16.22.0"
+version = "16.23.0"
 dependencies = [
  "pyo3",
 ]


### PR DESCRIPTION
Still not getting deno updates from dependabot.
This uses explicit paths to deno.json manifests,
instead of relying on the deno workspace config.

🤞
