### PR TITLE
fix: remove zizmor comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,7 @@ updates:
       uv-pip:
         patterns:
           - "*"
-  - package-ecosystem: deno # zizmor: ignore[dependabot-cooldown]
+  - package-ecosystem: deno
     directories:
       - /
       - /common

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,3 +5,5 @@ rules:
         actions/*: ref-pin
         github/*: ref-pin
         dependabot/*: ref-pin
+  dependabot-cooldown:
+    ignore: [dependabot.yml:44]


### PR DESCRIPTION
Zizmor is still configured to ignore rule for the deno ecosystem.

I just want to make sure the deno ecosystem was recognized in the dependabot config.